### PR TITLE
Remove async

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,9 @@
 {
-  "presets": [["env", { "targets": { "node": "8" } }]],
+  "presets": [
+    [
+      "env",
+      { "targets": { "browsers": ["> 1%", "last 2 versions", "Firefox ESR"] } }
+    ]
+  ],
   "plugins": ["add-module-exports"]
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "precommit": "lint-staged"
   },
   "dependencies": {
-    "babel-runtime": "^6.26.0",
     "raf-schd": "^2.0.1"
   },
   "devDependencies": {
@@ -32,12 +31,11 @@
     "babel-core": "^6.26.0",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-external-helpers": "^6.22.0",
-    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.0",
     "express": "^4.15.4",
     "husky": "^0.14.3",
     "lint-staged": "^4.1.3",
-    "prettier": "^1.6.1",
+    "prettier": "^1.7.0",
     "rimraf": "^2.6.2",
     "rollup": "^0.49.3",
     "rollup-plugin-babel": "^3.0.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -22,16 +22,6 @@ if (isProd) {
   output = { file: `dist/${pkg.name}.js`, format: 'umd', name };
 }
 
-const browsers = isProd
-  ? ['> 1%', 'last 2 versions', 'Firefox ESR']
-  : [
-      'Chrome >= 60',
-      'Safari >= 10.1',
-      'iOS >= 10.3',
-      'Firefox >= 54',
-      'Edge >= 15',
-    ];
-
 const plugins = [
   commonjs({
     ignoreGlobal: true,
@@ -44,18 +34,16 @@ const plugins = [
   }),
   babel({
     babelrc: false,
-    presets: [['env', { modules: false, targets: { browsers } }]],
-    plugins: [
-      'external-helpers',
+    presets: [
       [
-        'transform-runtime',
+        'env',
         {
-          helpers: false,
-          polyfill: false,
-          regenerator: true,
+          modules: false,
+          targets: { browsers: ['> 1%', 'last 2 versions', 'Firefox ESR'] },
         },
       ],
     ],
+    plugins: ['external-helpers'],
   }),
 ];
 

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ const createContainerState = container => {
   };
 };
 
-async function nockSlider(
+function nockSlider(
   slideContainer,
   imgs = [],
   {
@@ -61,21 +61,19 @@ async function nockSlider(
   );
 
   const initialImageSrc = images.next();
-  await loadAndSlide(initialImageSrc);
+  loadAndSlide(initialImageSrc);
 
-  const transition = next => async () => {
+  const transition = next => () => {
     const event = next ? 'next' : 'prev';
     const nextImageSrc = images[event]();
 
-    try {
-      await loadAndSlide(nextImageSrc);
-    } catch (error) {
-      callIfFunction(onSlideError, error);
+    loadAndSlide(nextImageSrc).catch(err => {
+      callIfFunction(onSlideError, err);
       containerState.isNotLoading();
 
       images.remove(nextImageSrc);
-      await transition(next)();
-    }
+      transition(next)();
+    });
   };
 
   btnPrevious && btnPrevious.addEventListener('click', transition(false));

--- a/src/utils/createImageSlider.js
+++ b/src/utils/createImageSlider.js
@@ -12,7 +12,7 @@ import {
 } from './dom';
 
 function createImageSlider(parent, transitionDelay = 0) {
-  return async blobUrl => {
+  return blobUrl => {
     const existingImg = parent.firstChild;
     const children = Array.from(parent.children);
     const nextImg = createElement('img', [imgClass]);

--- a/src/utils/memoize.js
+++ b/src/utils/memoize.js
@@ -5,19 +5,20 @@ function memoize(fn) {
   const getFromCache = p => prop(p, cache);
   const setInCache = (p, val) => assoc(p, val, cache);
 
-  return async (...args) => {
+  return (...args) => {
     let argsString = JSON.stringify(args);
     const resultFromCache = getFromCache(argsString);
 
     if (isNil(resultFromCache)) {
       !isProd() && console.log('Not found in cache');
-      const result = await fn(...args);
-      cache = setInCache(argsString, result);
-      return result;
+      return fn(...args).then(result => {
+        cache = setInCache(argsString, result);
+        return result;
+      });
     }
 
     !isProd() && console.log('Found in cache');
-    return resultFromCache;
+    return Promise.resolve(resultFromCache);
   };
 }
 

--- a/src/utils/preloadImg.js
+++ b/src/utils/preloadImg.js
@@ -1,21 +1,16 @@
-async function preloadImg(src) {
-  try {
-    const res = await fetch(src);
+function preloadImg(src) {
+  return fetch(src)
+    .then(res => {
+      if (res.status < 200 || res.status > 299) {
+        const error = new Error(res.statusText);
+        error.src = src;
+        error.code = res.status;
+        throw error;
+      }
 
-    if (res.status < 200 || res.status > 299) {
-      const error = new Error(res.statusText);
-      error.src = src;
-      error.code = res.status;
-      throw error;
-    }
-
-    const blob = await res.blob();
-    const blobUrl = URL.createObjectURL(blob);
-
-    return blobUrl;
-  } catch (error) {
-    throw error;
-  }
+      return res.blob();
+    })
+    .then(blob => URL.createObjectURL(blob));
 }
 
 export default preloadImg;

--- a/yarn.lock
+++ b/yarn.lock
@@ -507,12 +507,6 @@ babel-plugin-transform-regenerator@^6.22.0:
   dependencies:
     regenerator-transform "^0.10.0"
 
-babel-plugin-transform-runtime@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz#88490d446502ea9b8e7efb0fe09ec4d99479b1ee"
-  dependencies:
-    babel-runtime "^6.22.0"
-
 babel-plugin-transform-strict-mode@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz#d5faf7aa578a65bbe591cf5edae04a0c67020758"
@@ -1936,9 +1930,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.6.1.tgz#850f411a3116226193e32ea5acfc21c0f9a76d7d"
+prettier@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.7.0.tgz#47481588f41f7c90f63938feb202ac82554e7150"
 
 pretty-format@^20.0.3:
   version "20.0.3"


### PR DESCRIPTION
This PR removes all usage of async/await.

Even though it's a great syntax it produces to much overhead for a small library like this if one likes to support older browsers.

But users can still use async/await in their own implementation and take the increased file size-hit of including `regeneratorRuntime` if it's worth it.